### PR TITLE
컨트롤러 로직 및 테스트 구현

### DIFF
--- a/src/main/java/com/example/lectureservice/controller/LectureController.java
+++ b/src/main/java/com/example/lectureservice/controller/LectureController.java
@@ -1,0 +1,52 @@
+package com.example.lectureservice.controller;
+
+import com.example.lectureservice.controller.dto.LectureRequest;
+import com.example.lectureservice.service.LectureService;
+import com.example.lectureservice.service.domain.response.LectureApplyResponse;
+import com.example.lectureservice.service.domain.response.LectureResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/lectures")
+public class LectureController {
+    private final LectureService lectureService;
+
+    /**
+     * 특강 신청
+     * */
+    @PostMapping("/apply")
+    public ResponseEntity<LectureApplyResponse> apply(@RequestBody LectureRequest request) {
+        return ResponseEntity.status(HttpStatus.OK).body(lectureService.applyToLecture(request.toDomain()));
+    }
+
+    /**
+     * 특강 신청 완료 여부 조회
+     * 해당 유저가 신청한 특강이 조회됨
+     * */
+    @GetMapping("/application/{userId}")
+    public ResponseEntity<List<LectureApplyResponse>> isApplied(@PathVariable("userId") String userId) {
+        return ResponseEntity.status(HttpStatus.OK).body(lectureService.isAppliedLecture(userId));
+    }
+
+    /**
+     * 현재 신청할 수 있는 특강 리스트 조회
+     * */
+    @GetMapping("")
+    public ResponseEntity<List<LectureResponse>> selectLectureList() {
+        return ResponseEntity.status(HttpStatus.OK).body(lectureService.selectLectureList());
+    }
+
+    /**
+     * 한 특강의 시간별 강의 정보를 조회
+     * */
+    @GetMapping("/{lectureCode}")
+    public ResponseEntity<LectureResponse> selectLectureDetailList(@PathVariable("lectureCode") String lectureCode) {
+        return ResponseEntity.status(HttpStatus.OK).body(lectureService.selectLectureDetailList(lectureCode));
+    }
+}

--- a/src/test/java/com/example/lectureservice/controller/LectureControllerTest.java
+++ b/src/test/java/com/example/lectureservice/controller/LectureControllerTest.java
@@ -1,0 +1,153 @@
+package com.example.lectureservice.controller;
+
+import com.example.lectureservice.controller.dto.LectureRequest;
+import com.example.lectureservice.entity.LectureDetailEntity;
+import com.example.lectureservice.entity.LectureEntity;
+import com.example.lectureservice.service.LectureServiceImpl;
+import com.example.lectureservice.service.domain.response.LectureApplyResponse;
+import com.example.lectureservice.service.domain.response.LectureDetailsResponse;
+import com.example.lectureservice.service.domain.response.LectureResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest
+class LectureControllerTest {
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private LectureServiceImpl lectureService;
+
+    @DisplayName("특정 유저가 특강을 신청한다")
+    @Test
+    void apply() throws Exception {
+        // given
+        String lectureCode = "A00001";
+        String title = "물리학";
+        String name = "김재근";
+        LocalDateTime date = LocalDateTime.of(2024, 6, 24, 13, 0,0);
+        int maxParticipants = 30;
+        int currParticipants = 5;
+
+        String userId = "a1";
+
+        LectureRequest request = LectureRequest.builder()
+                .lectureCode(lectureCode)
+                .userId(userId)
+                .build();
+
+        LectureDetailEntity detail = LectureDetailEntity.builder()
+                .name(name)
+                .maxParticipants(maxParticipants)
+                .currParticipants(currParticipants)
+                .date(date)
+                .build();
+
+        List<LectureDetailEntity> details = List.of(detail);
+
+        LectureEntity entity = LectureEntity.builder()
+                .lectureCode(lectureCode)
+                .title(title)
+                .details(details)
+                .build();
+
+        // when
+        when(lectureService.applyToLecture(any())).thenReturn(LectureApplyResponse.of(entity));
+
+        // then
+        mockMvc.perform(post("/lectures/apply")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value(title))
+                .andExpect(jsonPath("$.date").value(date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"))))
+                .andExpect(jsonPath("$.title").value(title))
+                .andExpect(jsonPath("$.currParticipants").value(currParticipants));
+    }
+
+    @DisplayName("유저의 특강 신청 여부를 조회한다")
+    @Test
+    void isApplied_return_true() throws Exception {
+        // given
+        String userId = "a1";
+        String lectureCode = "A00001";
+        String title = "물리학";
+
+        LectureApplyResponse response = LectureApplyResponse.builder()
+                .lectureCode(lectureCode)
+                .title(title)
+                .build();
+
+        List<LectureApplyResponse> list = List.of(response, response);
+
+        // when
+        when(lectureService.isAppliedLecture(any())).thenReturn(list);
+
+        // then
+        mockMvc.perform(get("/lectures/application/{userId}", userId))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", Matchers.hasSize(2)))
+                .andExpect(jsonPath("$[0].lectureCode").value(lectureCode))
+                .andExpect(jsonPath("$[0].title").value(title))
+        ;
+    }
+
+    @DisplayName("신청 가능한 특강 목록을 조회한다")
+    @Test
+    void selectLectureList() throws Exception {
+        // given
+        String lectureCode1 = "A00001";
+        String lectureCode2 = "A00002";
+        String title1 = "물리학";
+        String title2 = "화학";
+        String name = "김재근";
+        LocalDateTime date = LocalDateTime.of(2024, 6, 24, 13, 0,0);
+
+        List<LectureResponse> responses = List.of(
+                new LectureResponse(lectureCode1, title1, List.of(
+                        new LectureDetailsResponse(name, date, 30, 20),
+                        new LectureDetailsResponse(name, date, 30, 20))),
+                new LectureResponse(lectureCode2, title2, List.of(new LectureDetailsResponse(name, date, 30, 10)))
+        );
+        // when
+        when(lectureService.selectLectureList()).thenReturn(responses);
+
+        // then
+        mockMvc.perform(get("/lectures"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].lectureCode").value("A00001"))
+                .andExpect(jsonPath("$[0].title").value("물리학"))
+                .andExpect(jsonPath("$[1].lectureCode").value("A00002"))
+                .andExpect(jsonPath("$[1].title").value("화학"))
+                .andExpect(jsonPath("$[0].details", Matchers.hasSize(2)))
+                .andExpect(jsonPath("$[1].details", Matchers.hasSize(1)))
+                .andExpect(jsonPath("$[0].details[0].currParticipants").value(20))
+                .andExpect(jsonPath("$[1].details[0].currParticipants").value(10));
+
+    }
+}


### PR DESCRIPTION
# 테이블 정보
## USER
- 유저 정보 저장 테이블

## LECTURE
- 특강 정보 저장 테이블
- 각각의 특강은 코드가 있으며 코드별로 날짜나 강사가 다를 수 있음
- 특강명과 코드는 변경되지 않음

## LECTURE_APPLY_HISTORY
- 특강을 신청한 유저의 정보가 저장되는 테이블

## LECTURE_DETAIL
- 특강의 세부 정보 테이블
- 강사명, 날짜, 최대 신청 인원, 현재 신청 인원 정보를 저장

## LECTURE_REG
- 특강 신청 목록 저장 테이블
- 특강 신청 성공 시, 유저 정보와 특강 id 저장. 취소시 삭제

# ERD
- https://dbdiagram.io/d/667bab689939893dae4875c1

# 리뷰 포인트
- ERD 에서 날짜별로 특강 정보를 따로 가져 가기 위해 DETAIL 테이블을 만들었습니다. 특강 코드와 특강명은 변하지 않는다는 가정하에 분리했는데 메인 테이블이 정보가 적고 비효율적이라는 느낌이라 반정규화를 해도 괜찮겠다는 생각이 듭니다. 어떤 설계가 더 좋을까요?