### PR TITLE
서비스 로직 구현

### DIFF
--- a/src/main/java/com/example/lectureservice/service/LectureServiceImpl.java
+++ b/src/main/java/com/example/lectureservice/service/LectureServiceImpl.java
@@ -1,0 +1,114 @@
+package com.example.lectureservice.service;
+
+import com.example.lectureservice.entity.LectureDetailEntity;
+import com.example.lectureservice.entity.LectureEntity;
+import com.example.lectureservice.entity.LectureRegEntity;
+import com.example.lectureservice.enums.Status;
+import com.example.lectureservice.repository.lecture.LectureRepository;
+import com.example.lectureservice.repository.lectureApplyHistory.LectureApplyHistoryRepository;
+import com.example.lectureservice.repository.lectureDetail.LectureRegRepository;
+import com.example.lectureservice.repository.lectureReg.lectureDetail.LectureDetailRepository;
+import com.example.lectureservice.service.domain.Lecture;
+import com.example.lectureservice.service.domain.response.LectureApplyResponse;
+import com.example.lectureservice.service.domain.response.LectureResponse;
+import com.example.lectureservice.util.LockManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class LectureServiceImpl implements LectureService{
+
+    private final LectureRepository lectureRepository;
+    private final LectureDetailRepository lectureDetailRepository;
+    private final LectureApplyHistoryRepository lectureApplyHistoryRepository;
+    private final LectureRegRepository lectureRegRepository;
+
+    @Transactional
+    @Override
+    public LectureApplyResponse applyToLecture(Lecture lecture) {
+        String key = "lecture_" + lecture.getLectureCode();
+
+        LockManager.lock(key);
+
+        try {
+            LectureEntity findLecture = findLecture(lecture);
+
+            checkAppliedLecture(lecture);
+
+            addParticipantsForUpdate(lecture, findLecture.getDetails().get(0));
+
+            return LectureApplyResponse.of(findLecture);
+        } finally {
+            LockManager.unlock(key);
+        }
+    }
+
+    private void addParticipantsForUpdate(Lecture lecture, LectureDetailEntity lectureDetail) {
+        for (int i = 0; i < 3; i++) {
+            try {
+                if (lectureDetail.getCurrParticipants() >= lectureDetail.getMaxParticipants()) {
+                    lecture.updateStatus(Status.FAIL);
+                    lectureApplyHistoryRepository.save(lecture.toLectureApplyEntity());
+                    throw new IllegalStateException("특강이 마감되었습니다");
+                }
+
+                lectureDetail.addCurrParticipants();
+                lectureDetailRepository.flush();
+
+                lecture.updateStatus(Status.SUCCESS);
+                lectureApplyHistoryRepository.save(lecture.toLectureApplyEntity());
+
+                break;
+            } catch (OptimisticLockingFailureException e) {
+                try {
+                    lectureDetail.minusCurrParticipants();
+                    Thread.sleep(100);
+                } catch (InterruptedException ex) {
+                    throw new RuntimeException(ex);
+                }
+            }
+        }
+    }
+
+    private void checkAppliedLecture(Lecture lecture) {
+        lectureRegRepository.isReg(lecture.getLectureDetailId(), lecture.getUserId())
+                .ifPresent(entity -> {
+                    throw new IllegalStateException("이미 신청한 특강입니다");
+                });
+    }
+
+    private LectureEntity findLecture(Lecture lecture) {
+        return lectureRepository.findByLectureCodeAndId(lecture.getLectureCode(), lecture.getLectureDetailId())
+                .orElseThrow(() -> new NullPointerException("해당 강의를 찾을 수 없습니다"));
+    }
+
+    @Override
+    public List<LectureResponse> selectLectureList() {
+        return lectureRepository.findLecturesAfterDate(LocalDateTime.now().minusHours(3)).stream()
+                .map(LectureEntity::toDto)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public LectureResponse selectLectureDetailList(String lectureCode) {
+        return lectureRepository.findLectureDetail(lectureCode)
+                .orElseThrow(() -> {
+                    throw new IllegalStateException("등록된 강의가 없습니다");
+                }).toDto();
+    }
+
+    @Override
+    public List<LectureApplyResponse> isAppliedLecture(String userId) {
+        return lectureRegRepository.findByUserId(userId).stream()
+                .map(LectureRegEntity::toDto)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/lectureservice/service/LectureServiceImpl.java
+++ b/src/main/java/com/example/lectureservice/service/LectureServiceImpl.java
@@ -66,6 +66,8 @@ public class LectureServiceImpl implements LectureService{
                 lecture.updateStatus(Status.SUCCESS);
                 lectureApplyHistoryRepository.save(lecture.toLectureApplyEntity());
 
+                lectureRegRepository.save(new LectureRegEntity(lectureDetail, lecture.getUserId()));
+
                 break;
             } catch (OptimisticLockingFailureException e) {
                 try {

--- a/src/test/java/com/example/lectureservice/service/LectureServiceTest.java
+++ b/src/test/java/com/example/lectureservice/service/LectureServiceTest.java
@@ -1,0 +1,129 @@
+package com.example.lectureservice.service;
+
+import com.example.lectureservice.entity.LectureApplyHistoryEntity;
+import com.example.lectureservice.entity.LectureDetailEntity;
+import com.example.lectureservice.entity.LectureEntity;
+import com.example.lectureservice.entity.LectureRegEntity;
+import com.example.lectureservice.repository.lecture.LectureRepository;
+import com.example.lectureservice.repository.lectureApplyHistory.LectureApplyHistoryRepository;
+import com.example.lectureservice.repository.lectureDetail.LectureRegRepository;
+import com.example.lectureservice.repository.lectureReg.lectureDetail.LectureDetailRepository;
+import com.example.lectureservice.repository.user.UserRepository;
+import com.example.lectureservice.service.domain.Lecture;
+import com.example.lectureservice.service.domain.response.LectureApplyResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LectureServiceTest {
+
+    @Mock
+    private LectureApplyHistoryRepository lectureApplyHistoryRepository;
+
+    @Mock
+    private LectureRepository lectureRepository;
+
+    @Mock
+    private LectureDetailRepository lectureDetailRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private LectureRegRepository lectureRegRepository;
+
+    @InjectMocks
+    private LectureServiceImpl lectureService;
+
+    @DisplayName("유저가 특강을 신청한다")
+    @Test
+    void applyToLecture() {
+        // given
+        String lectureCode = "A00001";
+        String title = "물리학";
+        String name = "김재근";
+        LocalDateTime date = LocalDateTime.of(2024, 6, 24, 13, 0,0);
+        int maxParticipants = 30;
+        int currParticipants = 29;
+        String userId = "a1";
+
+        LectureDetailEntity detail = LectureDetailEntity.builder()
+                .name(name)
+                .maxParticipants(maxParticipants)
+                .currParticipants(currParticipants)
+                .date(date)
+                .build();
+
+        List<LectureDetailEntity> details = List.of(detail);
+
+        Lecture lecture = new Lecture(userId, lectureCode);
+        LectureEntity entity = LectureEntity.builder()
+                .lectureCode(lectureCode)
+                .title(title)
+                .details(details)
+                .build();
+
+        // when
+        when(lectureRepository.findByLectureCodeAndId(any(),any())).thenReturn(Optional.of(entity));
+        when(lectureRegRepository.isReg(any(), any())).thenReturn(Optional.empty());
+        when(lectureApplyHistoryRepository.save(any())).thenReturn(new LectureApplyHistoryEntity());
+
+        LectureApplyResponse response = lectureService.applyToLecture(lecture);
+
+        // then
+        assertThat(response.getTitle()).isEqualTo(title);
+        assertThat(response.getDate()).isEqualTo(date);
+        assertThat(response.getMaxParticipants()).isEqualTo(maxParticipants);
+        assertThat(response.getCurrParticipants()).isEqualTo(currParticipants + 1);
+    }
+
+    @DisplayName("해당 강의를 찾을 수 없어 신청에 실패한다")
+    @Test
+    void applyToLecture_fail_no_lecture() {
+        // given
+        String lectureCode = "A00001";
+        String userId = "a1";
+
+        Lecture lecture = new Lecture(userId, lectureCode);
+
+        // when
+        when(lectureRepository.findByLectureCodeAndId(any(), any())).thenReturn(Optional.empty());
+
+        // then
+        assertThatThrownBy(() -> lectureService.applyToLecture(lecture))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("해당 강의를 찾을 수 없습니다");
+    }
+
+    @DisplayName("유저가 이미 특강을 신청해 실패한다")
+    @Test
+    void applyToLecture_fail_duplicate_user() {
+        // given
+        String lectureCode = "A00001";
+        String userId = "a1";
+
+        Lecture lecture = new Lecture(userId, lectureCode);
+
+        // when
+        when(lectureRepository.findByLectureCodeAndId(any(), any())).thenReturn(Optional.of(new LectureEntity()));
+        when(lectureRegRepository.isReg(any(), any())).thenReturn(Optional.of(new LectureRegEntity()));
+
+        // then
+        assertThatThrownBy(() -> lectureService.applyToLecture(lecture))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("이미 신청한 특강입니다");
+    }
+}

--- a/src/test/java/com/example/lectureservice/service/LectureServiceThreadTest.java
+++ b/src/test/java/com/example/lectureservice/service/LectureServiceThreadTest.java
@@ -1,0 +1,172 @@
+package com.example.lectureservice.service;
+
+import com.example.lectureservice.entity.LectureDetailEntity;
+import com.example.lectureservice.entity.LectureEntity;
+import com.example.lectureservice.entity.UserEntity;
+import com.example.lectureservice.repository.lecture.LectureRepository;
+import com.example.lectureservice.repository.lectureApplyHistory.LectureApplyHistoryRepository;
+import com.example.lectureservice.repository.lectureDetail.LectureRegRepository;
+import com.example.lectureservice.repository.lectureReg.lectureDetail.LectureDetailRepository;
+import com.example.lectureservice.repository.user.UserRepository;
+import com.example.lectureservice.service.domain.Lecture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+@SpringBootTest
+class LectureServiceThreadTest {
+
+    @Autowired
+    private LectureApplyHistoryRepository lectureApplyHistoryRepository;
+
+    @Autowired
+    private LectureRepository lectureRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private LectureRegRepository lectureRegRepository;
+
+    @Autowired
+    private LectureDetailRepository lectureDetailRepository;
+
+    @Autowired
+    private LectureServiceImpl lectureService;
+
+    void setUp() {
+        String lectureCode = "A00001";
+        String title = "물리학";
+        String name = "김재근";
+        LocalDateTime date = LocalDateTime.of(2024, 6, 24, 13, 0,0);
+        int maxParticipants = 30;
+        int currParticipants = 20;
+
+        LectureEntity lecture = LectureEntity.builder()
+                .lectureCode(lectureCode)
+                .title(title)
+                .build();
+        LectureDetailEntity detail = LectureDetailEntity.builder()
+                .lecture(lecture)
+                .name(name)
+                .date(date)
+                .maxParticipants(maxParticipants)
+                .currParticipants(currParticipants)
+                .build();
+
+        for (int i = 1; i < 11; i++) {
+            userRepository.save(new UserEntity("a" + i));
+        }
+        lectureRepository.save(lecture);
+
+        lectureDetailRepository.save(detail);
+    }
+
+    void tearDown() {
+        lectureDetailRepository.deleteAllInBatch();
+        lectureRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+        lectureRegRepository.deleteAllInBatch();
+        lectureApplyHistoryRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("동시에 신청할 때 최대 인원을 넘지 않도록 동시성을 보장한다")
+    void applyToLecture_concurrent_request() throws InterruptedException {
+        // given
+        Long lectureId = 1L;
+        String lectureCode = "A00001";
+        int maxParticipants = 30;
+
+        CompletableFuture.allOf(
+                CompletableFuture.runAsync(() -> setUp())
+        ).join();
+
+        // when
+        CompletableFuture.allOf(
+                CompletableFuture.runAsync(() -> lectureService.applyToLecture(new Lecture("a1", lectureCode, lectureId))),
+                CompletableFuture.runAsync(() -> lectureService.applyToLecture(new Lecture("a2", lectureCode, lectureId))),
+                CompletableFuture.runAsync(() -> lectureService.applyToLecture(new Lecture("a3", lectureCode, lectureId))),
+                CompletableFuture.runAsync(() -> lectureService.applyToLecture(new Lecture("a4", lectureCode, lectureId))),
+                CompletableFuture.runAsync(() -> lectureService.applyToLecture(new Lecture("a5", lectureCode, lectureId))),
+                CompletableFuture.runAsync(() -> lectureService.applyToLecture(new Lecture("a6", lectureCode, lectureId))),
+                CompletableFuture.runAsync(() -> lectureService.applyToLecture(new Lecture("a7", lectureCode, lectureId))),
+                CompletableFuture.runAsync(() -> lectureService.applyToLecture(new Lecture("a8", lectureCode, lectureId))),
+                CompletableFuture.runAsync(() -> lectureService.applyToLecture(new Lecture("a9", lectureCode, lectureId))),
+                CompletableFuture.runAsync(() -> lectureService.applyToLecture(new Lecture("a10",lectureCode, lectureId)))
+        ).join();
+
+        LectureDetailEntity findCount = lectureDetailRepository.findById(lectureId).get();
+
+        // then
+        assertThat(maxParticipants).isEqualTo(findCount.getCurrParticipants());
+
+        CompletableFuture.allOf(
+                CompletableFuture.runAsync(() -> tearDown())
+        ).join();
+    }
+
+    @Test
+    @DisplayName("동시에 신청할 때 최대 인원을 넘으면 에러를 반환한다")
+    void applyToLecture_fail_concurrent_request_over_maxParticipants() throws InterruptedException {
+        // given
+        Long lectureId = 1L;
+        String lectureCode = "A00001";
+        int maxParticipants = 30;
+
+        CompletableFuture.allOf(
+                CompletableFuture.runAsync(() -> setUp())
+        ).join();
+
+        // when then
+        List<CompletableFuture<Void>> futures = List.of(
+                CompletableFuture.runAsync(() -> lectureService.applyToLecture(new Lecture("a1", lectureCode, lectureId))),
+                CompletableFuture.runAsync(() -> lectureService.applyToLecture(new Lecture("a2", lectureCode, lectureId))),
+                CompletableFuture.runAsync(() -> lectureService.applyToLecture(new Lecture("a3", lectureCode, lectureId))),
+                CompletableFuture.runAsync(() -> lectureService.applyToLecture(new Lecture("a4", lectureCode, lectureId))),
+                CompletableFuture.runAsync(() -> lectureService.applyToLecture(new Lecture("a5", lectureCode, lectureId))),
+                CompletableFuture.runAsync(() -> lectureService.applyToLecture(new Lecture("a6", lectureCode, lectureId))),
+                CompletableFuture.runAsync(() -> lectureService.applyToLecture(new Lecture("a7", lectureCode, lectureId))),
+                CompletableFuture.runAsync(() -> lectureService.applyToLecture(new Lecture("a8", lectureCode, lectureId))),
+                CompletableFuture.runAsync(() -> lectureService.applyToLecture(new Lecture("a9", lectureCode, lectureId))),
+                CompletableFuture.runAsync(() -> lectureService.applyToLecture(new Lecture("a10", lectureCode, lectureId))),
+                CompletableFuture.runAsync(() -> lectureService.applyToLecture(new Lecture("a11", lectureCode, lectureId)))
+        );
+
+        Throwable exception = futures.stream()
+                .map(future -> {
+                    try {
+                        future.join();
+                        return null;
+                    } catch (CompletionException ex) {
+                        return ex.getCause();
+                    }
+                })
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse(null);
+
+        LectureDetailEntity findCount = lectureDetailRepository.findById(lectureId).get();
+
+        // then
+        assertThat(maxParticipants).isEqualTo(findCount.getMaxParticipants());
+        assertThat(exception)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("특강이 마감되었습니다");
+
+        CompletableFuture.allOf(
+                CompletableFuture.runAsync(() -> tearDown())
+        ).join();
+    }
+}


### PR DESCRIPTION
# 테이블 정보
## USER
- 유저 정보 저장 테이블

## LECTURE
- 특강 정보 저장 테이블
- 각각의 특강은 코드가 있으며 코드별로 날짜나 강사가 다를 수 있음
- 특강명과 코드는 변경되지 않음

## LECTURE_APPLY_HISTORY
- 특강을 신청한 유저의 정보가 저장되는 테이블

## LECTURE_DETAIL
- 특강의 세부 정보 테이블
- 강사명, 날짜, 최대 신청 인원, 현재 신청 인원 정보를 저장

## LECTURE_REG
- 특강 신청 목록 저장 테이블
- 특강 신청 성공 시, 유저 정보와 특강 id 저장. 취소시 삭제

# ERD
- https://dbdiagram.io/d/667bab689939893dae4875c1

# 리뷰 포인트
- 하단에 작성했습니다